### PR TITLE
Potential fix for code scanning alert no. 5: Disabled Spring CSRF protection

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		BearerAuthenticationFilter filter = new BearerAuthenticationFilter(authenticationManager(), this.antPattern);
 		filter.setAuthenticationSuccessHandler(jwtAuthenticationSuccessHandler);
 		http.cors().and()
-			 .csrf().disable()
+			 .csrf().ignoringAntMatchers("/api/public/**").and() // Allow specific endpoints to bypass CSRF
 			 .authorizeRequests().antMatchers(this.antPattern).authenticated().and()
 			 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
 			 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Potential fix for [https://github.com/AftabShaikh/ghas-bootcamp/security/code-scanning/5](https://github.com/AftabShaikh/ghas-bootcamp/security/code-scanning/5)

To fix the issue, CSRF protection should be re-enabled unless there is a compelling reason to disable it. If certain endpoints need to bypass CSRF protection (e.g., for APIs used by non-browser clients), this can be achieved by customizing the CSRF configuration to exclude those specific endpoints. 

The following changes will:
1. Remove the `csrf().disable()` call.
2. Add a custom CSRF configuration to allow certain endpoints (if necessary) to bypass CSRF protection while keeping it enabled for others.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
